### PR TITLE
pass `expected` object to `match` function for more flexible plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,39 @@ Then we can assert as below:
     number: 'not a number'
   });
 ```
+
+### Plugin for testing strings with RegExp
+
+If some strings require fuzzy matching we can do this with a plugin as follows: 
+
+```js
+var chai = require('chai');
+var like = require('chai-like');
+
+var regexPlugin = like.extend({
+  match: function(object, expected) {
+    return typeof object === 'string' && expected instanceof RegExp;
+  },
+  assert: function(object, expected) {
+    return expected.test(object);
+  }
+});
+
+like.extend(regexPlugin);
+
+chai.use(like);
+```
+
+Then we can assert as below:
+
+```js
+var object = {
+  text: 'the quick brown fox jumps over the lazy dog'
+};
+object.should.like({
+  text: /.* jumps over .*/
+});
+object.should.not.like({
+  text: /\d/
+});
+```

--- a/lib/chai-like.js
+++ b/lib/chai-like.js
@@ -4,7 +4,7 @@ module.exports = function(_chai, utils) {
   function like(object, expected) {
     for (var index = 0; index < plugins.length; index++) {
       var validator = plugins[0];
-      if (validator.match(object)) {
+      if (validator.match(object, expected)) {
         return validator.assert(object, expected);
       }
     }

--- a/test/chai-like-plugin.js
+++ b/test/chai-like-plugin.js
@@ -26,4 +26,27 @@ describe('chai-like plugin', function() {
 
     like.clearPlugins();
   });
+
+  it('should test a string with expected RegExp', function () {
+      like.extend({
+          match: function(object, expected) {
+              return typeof object === 'string' && expected instanceof RegExp;
+          },
+          assert: function(object, expected) {
+              return expected.test(object);
+          }
+      });
+
+      var object = {
+          text: 'the quick brown fox jumps over the lazy dog'
+      };
+      object.should.like({
+          text: /.* jumps over .*/
+      });
+      object.should.not.like({
+          text: /\d/
+      });
+
+      like.clearPlugins();
+  });
 });


### PR DESCRIPTION
Hey @zation, I really like you lib.

What do you think about a small change like this?

May be the new paragraph in readme is redundant, but I think it describes quite common case.