### PR TITLE
Fix typo in type detection.

### DIFF
--- a/lib/chai-like.js
+++ b/lib/chai-like.js
@@ -9,7 +9,7 @@ module.exports = function(_chai, utils) {
       }
     }
 
-    if (utils.type(expected) === 'object' && utils.type(object) === 'object') {
+    if (utils.type(expected) === 'Object' && utils.type(object) === 'Object') {
       for (var key in expected) {
         if (expected.hasOwnProperty(key)) {
           if (!like(object[key], expected[key])) {
@@ -20,7 +20,7 @@ module.exports = function(_chai, utils) {
       return true;
     }
 
-    if (utils.type(expected) === 'array' && utils.type(object) === 'array') {
+    if (utils.type(expected) === 'Array' && utils.type(object) === 'Array') {
       for (var i = 0; i < expected.length; i++) {
         if (!like(object[i], expected[i])) {
           return false;


### PR DESCRIPTION
Chai uses [type-detect](https://www.npmjs.com/package/type-detect) library that returns "Object" and "Array" types always starting with capitals. 

I figured this out when trying to use `chai-like` along with `chai-things` like this: 
```js
var chai = require('chai');
var expect = chai.expect;
chai.use(require('chai-like'));
chai.use(require('chai-things'));

var data = [ { name: 'test', asdf: 'qwerty' }, { name: 'sth' } ];
expect(data).to.be.an('array').that.includes.something.like({name: 'test'});
```

It still breaks when I sswitch the `.use()` callings (I don't understand the plugin mechanism that much yet), but it correctly detects the types now. 