### PR TITLE
Fix object wrapper compare

### DIFF
--- a/lib/chai-like.js
+++ b/lib/chai-like.js
@@ -43,6 +43,15 @@ module.exports = function(_chai, utils) {
       return true;
     }
 
+    // Special case for RegExps because literal regexp (/.../) not equal new RegExp(...)
+    if (isType('RegExp', object) && isType('RegExp', expected)) {
+      return object.toString() === expected.toString();
+    }
+
+    if (isType('Date', object) && isType('Date', expected)) {
+      return object.getTime() === expected.getTime();
+    }
+
     return false;
   }
 

--- a/lib/chai-like.js
+++ b/lib/chai-like.js
@@ -52,6 +52,14 @@ module.exports = function(_chai, utils) {
       return object.getTime() === expected.getTime();
     }
 
+    // Do reflexed compare so primitives and object wrappers will be equal
+    if (isType('string', object) && isType('string', expected)
+     || isType('number', object) && isType('number', expected)
+     || isType('boolean', object) && isType('boolean', expected)
+    ) {
+      return object == expected;
+    }
+
     return false;
   }
 

--- a/test/chai-like.js
+++ b/test/chai-like.js
@@ -8,6 +8,80 @@ chai.use(like);
 const expect = chai.expect;
 
 describe('chai-like', function() {
+  describe('should match primitives', function() {
+    var string = 'Question about life, universe and everything';
+    var number = 42;
+    var TRUE = true;
+    var FALSE = false;
+    var array = [string, number];
+    var object = { question: string, answer: number };
+
+    function fn() {}
+
+    it('string', function() {
+      ('').should.like('');
+      string.should.like(string);
+      string.should.like('Question about life, universe and everything');
+    });
+
+    it('number', function() {
+      number.should.like(number);
+      number.should.like(42);
+
+      number.should.not.like(NaN);
+      NaN.should.not.like(number);
+
+      NaN.should.not.like(NaN);
+    });
+
+    it('boolean', function() {
+      TRUE.should.like(TRUE);
+      TRUE.should.like(true);
+
+      FALSE.should.like(FALSE);
+      FALSE.should.like(false);
+    });
+
+    it('array', function() {
+      ([]).should.like([]);
+      array.should.like(array);
+      array.should.like([string, number]);
+    });
+
+    it('object', function() {
+      ({}).should.like({});
+      object.should.like(object);
+      object.should.like({ question: string, answer: number });
+    });
+
+    it('function', function() {
+      fn.should.like(fn);
+    });
+  });
+
+  it('should match RegExps', function() {
+    var regexp = /[abc]/;
+
+    regexp.should.like(regexp);
+    regexp.should.like(RegExp('[abc]'));
+    RegExp('[abc]').should.like(regexp);
+    new RegExp('[abc]').should.like(regexp);
+  });
+
+  it('should match Dates', function() {
+    var date = new Date(2018, 0, 4, 22, 6, 15, 777);
+
+    date.should.like(date);
+    date.should.like(new Date(2018, 0, 4, 22, 6, 15, 777));
+    date.should.not.like(new Date(2019, 0, 4, 22, 6, 15, 777));
+    date.should.not.like(new Date(2018, 1, 4, 22, 6, 15, 777));
+    date.should.not.like(new Date(2018, 0, 5, 22, 6, 15, 777));
+    date.should.not.like(new Date(2018, 0, 4, 23, 6, 15, 777));
+    date.should.not.like(new Date(2018, 0, 4, 22, 7, 15, 777));
+    date.should.not.like(new Date(2018, 0, 4, 22, 6, 16, 777));
+    date.should.not.like(new Date(2018, 0, 4, 22, 6, 15, 778));
+  });
+
   it('should differentiate `null` and `undefined`', function() {
     expect(undefined).like(undefined);
     expect(undefined).not.like(null);

--- a/test/chai-like.js
+++ b/test/chai-like.js
@@ -57,6 +57,46 @@ describe('chai-like', function() {
     it('function', function() {
       fn.should.like(fn);
     });
+
+    describe('with their object wrappers', function() {
+      it('string', function() {
+        string.should.like(String(string));
+        string.should.like(new String(string));
+
+        String(string).should.like(string);
+        new String(string).should.like(string);
+      });
+
+      it('number', function() {
+        number.should.like(Number(number));
+        number.should.like(new Number(number));
+
+        Number(number).should.like(number);
+        new Number(number).should.like(number);
+      });
+
+      it('boolean', function() {
+        TRUE .should.like(Boolean(true));
+        FALSE.should.like(Boolean(false));
+        TRUE .should.like(new Boolean(true));
+        FALSE.should.like(new Boolean(false));
+
+        Boolean(true ).should.like(TRUE);
+        Boolean(false).should.like(FALSE);
+        new Boolean(true ).should.like(TRUE);
+        new Boolean(false).should.like(FALSE);
+      });
+
+      it('array', function() {
+        ([]).should.like(new Array());
+
+        array.should.like(Array(string, number));
+        array.should.like(new Array(string, number));
+
+        Array(string, number).should.like(array);
+        new Array(string, number).should.like(array);
+      });
+    });
   });
 
   it('should match RegExps', function() {


### PR DESCRIPTION
I found, that primitive strings, numbers and booleans do not match their object wrappers. I think that this is mostly unexpected rather then expected, but it may be discussed